### PR TITLE
Add corridor-based trajectory planning framework

### DIFF
--- a/cfg/FTCPlanner.cfg
+++ b/cfg/FTCPlanner.cfg
@@ -50,10 +50,26 @@ grp_recovery.add("oscillation_omega_eps", double_t, 0, "Oscillation omega eps", 
 grp_recovery.add("oscillation_recovery_min_duration", double_t, 0, "duration until recovery in s", 5.0, 0.0, 100.0)
 
 # Obstacles
-grp_obstacles = gen.add_group("obstacles", type="tab")   
+grp_obstacles = gen.add_group("obstacles", type="tab")
 grp_obstacles.add("check_obstacles", bool_t, 0, "check and stop for obstacles in path", True)
 grp_obstacles.add("obstacle_lookahead", int_t, 0, "how many path segments should be used for collision check", 5,0,20)
 grp_obstacles.add("obstacle_footprint", bool_t, 0, "check footprint at actual pose for collision", True)
 grp_obstacles.add("debug_obstacle", bool_t, 0, "debug obstacle check as marker array", True)
+
+grp_corridor = gen.add_group("corridor", type="tab")
+grp_corridor.add("enable_corridor_planning", bool_t, 0, "Enable corridor constrained local planning", False)
+grp_corridor.add("corridor_length", double_t, 0, "Maximum length of the local corridor window", 5.0, 0.5, 20.0)
+grp_corridor.add("corridor_sampling_step", double_t, 0, "Resolution when sampling collision cost along candidate trajectories", 0.2, 0.05, 1.0)
+grp_corridor.add("corridor_max_half_width", double_t, 0, "Maximum lateral half width of the corridor", 1.0, 0.1, 5.0)
+grp_corridor.add("corridor_lateral_resolution", double_t, 0, "Resolution when probing lateral limits in the costmap", 0.1, 0.02, 1.0)
+grp_corridor.add("corridor_lateral_samples", int_t, 0, "Number of lateral samples on each side of the centerline", 4, 0, 10)
+grp_corridor.add("corridor_collision_weight", double_t, 0, "Weight for collision costs when evaluating candidates", 5.0, 0.0, 50.0)
+grp_corridor.add("corridor_offset_weight", double_t, 0, "Weight penalizing lateral offset from the centerline", 1.0, 0.0, 50.0)
+grp_corridor.add("corridor_smoothness_weight", double_t, 0, "Weight penalizing lateral offset changes between samples", 2.0, 0.0, 50.0)
+grp_corridor.add("corridor_progress_weight", double_t, 0, "Weight rewarding forward progress along the window", 1.0, 0.0, 20.0)
+grp_corridor.add("corridor_dynamic_weight", double_t, 0, "Reserved weight for dynamic risk (currently unused)", 0.0, 0.0, 20.0)
+grp_corridor.add("corridor_lethal_cost", double_t, 0, "Cost threshold treated as collision when probing the costmap", 253.0, 1.0, 255.0)
+grp_corridor.add("corridor_tracking_lookahead", double_t, 0, "Distance along the best path used to pick the tracking point", 1.0, 0.0, 5.0)
+grp_corridor.add("corridor_publish_debug", bool_t, 0, "Publish corridor centerline, bounds and best trajectory for debugging", True)
 
 exit(gen.generate("ftc_local_planner", "ftc_local_planner", "FTCPlanner"))

--- a/include/ftc_local_planner/ftc_planner.h
+++ b/include/ftc_local_planner/ftc_planner.h
@@ -22,6 +22,8 @@
 #include "tf2_eigen/tf2_eigen.h"
 #include <mbf_costmap_core/costmap_controller.h>
 #include <visualization_msgs/Marker.h>
+#include <vector>
+#include <utility>
 
 namespace ftc_local_planner
 {
@@ -57,6 +59,9 @@ namespace ftc_local_planner
         ros::Publisher global_plan_pub;
         ros::Publisher progress_pub;
         ros::Publisher obstacle_marker_pub;
+        ros::Publisher corridor_centerline_pub_;
+        ros::Publisher best_trajectory_pub_;
+        ros::Publisher corridor_boundary_pub_;
 
         FTCPlannerConfig config;
 
@@ -95,6 +100,8 @@ namespace ftc_local_planner
         bool oscillation_detected_ = false;
         bool oscillation_warning_ = false;
 
+        std::vector<Eigen::Vector2d> last_best_path_world_;
+
         double distanceLookahead();
         PlannerState update_planner_state();
         void update_control_point(double dt);
@@ -126,6 +133,22 @@ namespace ftc_local_planner
          * @return sum of `values`, or 0.0 if `values` is empty.
          */
         void debugObstacle(visualization_msgs::Marker &obstacle_points, double x, double y, unsigned char cost, int maxIDs);
+
+        bool planCorridorTarget(const Eigen::Affine3d &fallback, Eigen::Affine3d &corridor_target);
+        bool extractLocalCenterline(std::string &frame_id, std::vector<Eigen::Vector2d> &centerline,
+                                    std::vector<double> &headings, std::vector<double> &cumulative_distance,
+                                    std::vector<size_t> &indices);
+        void computeCorridorBounds(const std::vector<Eigen::Vector2d> &centerline, const std::vector<double> &headings,
+                                   std::vector<std::pair<double, double>> &bounds);
+        bool generateBestTrajectory(const std::vector<Eigen::Vector2d> &centerline, const std::vector<double> &headings,
+                                    const std::vector<double> &cumulative_distance,
+                                    const std::vector<std::pair<double, double>> &bounds,
+                                    std::vector<Eigen::Vector2d> &best_path);
+        double costAt(const Eigen::Vector2d &point, bool &lethal);
+        double segmentCollisionCost(const Eigen::Vector2d &from, const Eigen::Vector2d &to, bool &lethal);
+        void publishCorridorDebug(const std::string &frame_id, const std::vector<Eigen::Vector2d> &centerline,
+                                  const std::vector<double> &headings, const std::vector<std::pair<double, double>> &bounds,
+                                  const std::vector<Eigen::Vector2d> &best_path);
 
         double time_in_current_state()
         {

--- a/src/ftc_planner.cpp
+++ b/src/ftc_planner.cpp
@@ -1,8 +1,13 @@
 
 #include <ftc_local_planner/ftc_planner.h>
 
+#include <algorithm>
+#include <limits>
+#include <cmath>
+
 #include <pluginlib/class_list_macros.h>
 #include "mbf_msgs/ExePathAction.h"
+#include <tf2/utils.h>
 
 PLUGINLIB_EXPORT_CLASS(ftc_local_planner::FTCPlanner, mbf_costmap_core::CostmapController)
 
@@ -27,6 +32,9 @@ namespace ftc_local_planner
         global_point_pub = private_nh.advertise<geometry_msgs::PoseStamped>("global_point", 1);
         global_plan_pub = private_nh.advertise<nav_msgs::Path>("global_plan", 1, true);
         obstacle_marker_pub = private_nh.advertise<visualization_msgs::Marker>("costmap_marker", 10);
+        corridor_centerline_pub_ = private_nh.advertise<nav_msgs::Path>("corridor_centerline", 1);
+        best_trajectory_pub_ = private_nh.advertise<nav_msgs::Path>("best_corridor_trajectory", 1);
+        corridor_boundary_pub_ = private_nh.advertise<visualization_msgs::Marker>("corridor_bounds", 1);
 
         costmap = costmap_ros;
         costmap_map_ = costmap->getCostmap();
@@ -106,6 +114,7 @@ namespace ftc_local_planner
             state_entered_time = ros::Time::now();
         }
         global_plan_pub.publish(path);
+        last_best_path_world_.clear();
 
         ROS_INFO_STREAM("FTCLocalPlannerROS: Got new global plan with " << plan.size() << " points.");
 
@@ -403,7 +412,22 @@ namespace ftc_local_planner
             result.translation() = (1.0 - current_progress) * trans1 + current_progress * trans2;
             result.linear() = rot1.slerp(current_progress, rot2).toRotationMatrix();
 
-            current_control_point = result;
+            if (config.enable_corridor_planning)
+            {
+                Eigen::Affine3d corridor_target;
+                if (planCorridorTarget(result, corridor_target))
+                {
+                    current_control_point = corridor_target;
+                }
+                else
+                {
+                    current_control_point = result;
+                }
+            }
+            else
+            {
+                current_control_point = result;
+            }
         }
         break;
         case POST_ROTATE:
@@ -427,6 +451,547 @@ namespace ftc_local_planner
         lat_error = local_control_point.translation().y();
         lon_error = local_control_point.translation().x();
         angle_error = local_control_point.rotation().eulerAngles(0, 1, 2).z();
+    }
+
+    bool FTCPlanner::planCorridorTarget(const Eigen::Affine3d &fallback, Eigen::Affine3d &corridor_target)
+    {
+        std::string frame_id;
+        std::vector<Eigen::Vector2d> centerline;
+        std::vector<double> headings;
+        std::vector<double> cumulative_distance;
+        std::vector<size_t> indices;
+        if (!extractLocalCenterline(frame_id, centerline, headings, cumulative_distance, indices))
+        {
+            return false;
+        }
+
+        std::vector<std::pair<double, double>> bounds(centerline.size(), std::make_pair(0.0, 0.0));
+        computeCorridorBounds(centerline, headings, bounds);
+
+        std::vector<Eigen::Vector2d> best_path;
+        if (!generateBestTrajectory(centerline, headings, cumulative_distance, bounds, best_path))
+        {
+            return false;
+        }
+
+        if (best_path.empty())
+        {
+            return false;
+        }
+
+        double lookahead_distance = std::max(0.0, config.corridor_tracking_lookahead);
+        size_t tracking_index = 0;
+        double accumulated = 0.0;
+        for (size_t i = 1; i < best_path.size(); ++i)
+        {
+            accumulated += (best_path[i] - best_path[i - 1]).norm();
+            if (accumulated >= lookahead_distance)
+            {
+                tracking_index = i;
+                break;
+            }
+        }
+        if (tracking_index >= best_path.size())
+        {
+            tracking_index = best_path.size() - 1;
+        }
+
+        Eigen::Vector2d heading_vec(1.0, 0.0);
+        if (tracking_index + 1 < best_path.size())
+        {
+            heading_vec = best_path[tracking_index + 1] - best_path[tracking_index];
+        }
+        else if (tracking_index > 0)
+        {
+            heading_vec = best_path[tracking_index] - best_path[tracking_index - 1];
+        }
+        else if (!headings.empty())
+        {
+            heading_vec = Eigen::Vector2d(std::cos(headings.front()), std::sin(headings.front()));
+        }
+
+        if (heading_vec.squaredNorm() < 1e-9)
+        {
+            double fallback_yaw = std::atan2(fallback.linear()(1, 0), fallback.linear()(0, 0));
+            heading_vec = Eigen::Vector2d(std::cos(fallback_yaw), std::sin(fallback_yaw));
+        }
+
+        double yaw = std::atan2(heading_vec.y(), heading_vec.x());
+
+        corridor_target = Eigen::Affine3d::Identity();
+        corridor_target.translation() = Eigen::Vector3d(best_path[tracking_index].x(), best_path[tracking_index].y(),
+                                                       fallback.translation().z());
+        corridor_target.linear() = Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+
+        publishCorridorDebug(frame_id, centerline, headings, bounds, best_path);
+        last_best_path_world_ = best_path;
+
+        return true;
+    }
+
+    bool FTCPlanner::extractLocalCenterline(std::string &frame_id, std::vector<Eigen::Vector2d> &centerline,
+                                            std::vector<double> &headings, std::vector<double> &cumulative_distance,
+                                            std::vector<size_t> &indices)
+    {
+        if (global_plan.size() < 2 || current_index >= global_plan.size())
+        {
+            return false;
+        }
+
+        frame_id = global_plan[current_index].header.frame_id;
+        centerline.clear();
+        headings.clear();
+        cumulative_distance.clear();
+        indices.clear();
+
+        double max_length = std::max(0.1, config.corridor_length);
+        double accumulated_distance = 0.0;
+
+        auto poseToVector = [](const geometry_msgs::PoseStamped &pose) {
+            return Eigen::Vector2d(pose.pose.position.x, pose.pose.position.y);
+        };
+
+        Eigen::Vector2d last_point = poseToVector(global_plan[current_index]);
+        centerline.push_back(last_point);
+        cumulative_distance.push_back(0.0);
+        indices.push_back(current_index);
+
+        size_t idx = current_index;
+        while (idx + 1 < global_plan.size() && accumulated_distance < max_length)
+        {
+            Eigen::Vector2d current_point = poseToVector(global_plan[idx]);
+            Eigen::Vector2d next_point = poseToVector(global_plan[idx + 1]);
+
+            double dist = (next_point - current_point).norm();
+            if (dist < 1e-6)
+            {
+                idx++;
+                continue;
+            }
+
+            accumulated_distance += dist;
+            centerline.push_back(next_point);
+            cumulative_distance.push_back(accumulated_distance);
+            indices.push_back(idx + 1);
+            last_point = next_point;
+            idx++;
+        }
+
+        if (centerline.size() < 2)
+        {
+            return false;
+        }
+
+        headings.resize(centerline.size(), 0.0);
+        for (size_t i = 0; i < centerline.size(); ++i)
+        {
+            Eigen::Vector2d direction(0.0, 0.0);
+            if (i + 1 < centerline.size())
+            {
+                direction = centerline[i + 1] - centerline[i];
+            }
+            else if (i > 0)
+            {
+                direction = centerline[i] - centerline[i - 1];
+            }
+
+            if (direction.norm() > 1e-6)
+            {
+                headings[i] = std::atan2(direction.y(), direction.x());
+            }
+            else
+            {
+                double yaw = tf2::getYaw(global_plan[indices[i]].pose.orientation);
+                headings[i] = yaw;
+            }
+        }
+
+        return true;
+    }
+
+    void FTCPlanner::computeCorridorBounds(const std::vector<Eigen::Vector2d> &centerline,
+                                           const std::vector<double> &headings,
+                                           std::vector<std::pair<double, double>> &bounds)
+    {
+        if (centerline.empty())
+        {
+            return;
+        }
+
+        double max_width = std::max(0.0, config.corridor_max_half_width);
+        double resolution = std::max(0.01, config.corridor_lateral_resolution);
+        double lethal_threshold = config.corridor_lethal_cost;
+
+        for (size_t i = 0; i < centerline.size(); ++i)
+        {
+            Eigen::Vector2d normal(-std::sin(headings[i]), std::cos(headings[i]));
+            double positive_limit = 0.0;
+            double negative_limit = 0.0;
+
+            for (double offset = resolution; offset <= max_width + 1e-6; offset += resolution)
+            {
+                bool lethal = false;
+                Eigen::Vector2d test_point = centerline[i] + normal * offset;
+                double cost = costAt(test_point, lethal) * 255.0;
+                if (lethal || cost >= lethal_threshold)
+                {
+                    break;
+                }
+                positive_limit = offset;
+            }
+
+            for (double offset = resolution; offset <= max_width + 1e-6; offset += resolution)
+            {
+                bool lethal = false;
+                Eigen::Vector2d test_point = centerline[i] - normal * offset;
+                double cost = costAt(test_point, lethal) * 255.0;
+                if (lethal || cost >= lethal_threshold)
+                {
+                    break;
+                }
+                negative_limit = offset;
+            }
+
+            bounds[i].first = -negative_limit;
+            bounds[i].second = positive_limit;
+        }
+    }
+
+    bool FTCPlanner::generateBestTrajectory(const std::vector<Eigen::Vector2d> &centerline,
+                                            const std::vector<double> &headings,
+                                            const std::vector<double> &cumulative_distance,
+                                            const std::vector<std::pair<double, double>> &bounds,
+                                            std::vector<Eigen::Vector2d> &best_path)
+    {
+        best_path.clear();
+
+        if (centerline.empty())
+        {
+            return false;
+        }
+
+        size_t N = centerline.size();
+        int lateral_samples = std::max(0, config.corridor_lateral_samples);
+        double max_offset = std::max(0.0, config.corridor_max_half_width);
+
+        std::vector<double> offset_samples;
+        offset_samples.push_back(0.0);
+        if (lateral_samples > 0 && max_offset > 0.0)
+        {
+            double step = max_offset / static_cast<double>(lateral_samples);
+            for (int i = 1; i <= lateral_samples; ++i)
+            {
+                double value = step * static_cast<double>(i);
+                offset_samples.push_back(value);
+                offset_samples.push_back(-value);
+            }
+        }
+        std::sort(offset_samples.begin(), offset_samples.end());
+
+        size_t K = offset_samples.size();
+        const double INF = std::numeric_limits<double>::infinity();
+
+        std::vector<std::vector<double>> dp(N, std::vector<double>(K, INF));
+        std::vector<std::vector<int>> parent(N, std::vector<int>(K, -1));
+        std::vector<std::vector<bool>> valid(N, std::vector<bool>(K, false));
+        std::vector<std::vector<Eigen::Vector2d>> points(N, std::vector<Eigen::Vector2d>(K, Eigen::Vector2d::Zero()));
+        std::vector<std::vector<double>> point_costs(N, std::vector<double>(K, INF));
+
+        double collision_weight = std::max(0.0, config.corridor_collision_weight);
+        double offset_weight = std::max(0.0, config.corridor_offset_weight);
+        double smoothness_weight = std::max(0.0, config.corridor_smoothness_weight);
+        double progress_weight = std::max(0.0, config.corridor_progress_weight);
+
+        for (size_t i = 0; i < N; ++i)
+        {
+            Eigen::Vector2d normal(-std::sin(headings[i]), std::cos(headings[i]));
+            for (size_t j = 0; j < K; ++j)
+            {
+                double offset = offset_samples[j];
+                if (offset < bounds[i].first - 1e-6 || offset > bounds[i].second + 1e-6)
+                {
+                    continue;
+                }
+                Eigen::Vector2d candidate = centerline[i] + normal * offset;
+                bool lethal = false;
+                double collision_cost = costAt(candidate, lethal);
+                if (lethal)
+                {
+                    continue;
+                }
+                points[i][j] = candidate;
+                valid[i][j] = true;
+                double point_cost = collision_weight * collision_cost + offset_weight * offset * offset;
+                if (i > 0)
+                {
+                    point_cost -= progress_weight * (cumulative_distance[i] - cumulative_distance[i - 1]);
+                }
+                else
+                {
+                    point_cost -= progress_weight * cumulative_distance[i];
+                }
+                point_costs[i][j] = point_cost;
+                if (i == 0)
+                {
+                    dp[i][j] = point_cost;
+                }
+            }
+        }
+
+        for (size_t i = 1; i < N; ++i)
+        {
+            for (size_t j = 0; j < K; ++j)
+            {
+                if (!valid[i][j])
+                {
+                    continue;
+                }
+
+                double point_cost = point_costs[i][j];
+                if (!std::isfinite(point_cost))
+                {
+                    continue;
+                }
+
+                double offset = offset_samples[j];
+                for (size_t pj = 0; pj < K; ++pj)
+                {
+                    if (!valid[i - 1][pj])
+                    {
+                        continue;
+                    }
+
+                    if (dp[i - 1][pj] >= INF)
+                    {
+                        continue;
+                    }
+
+                    bool lethal = false;
+                    double seg_cost = segmentCollisionCost(points[i - 1][pj], points[i][j], lethal);
+                    if (lethal)
+                    {
+                        continue;
+                    }
+
+                    double smooth_cost = smoothness_weight * std::pow(offset - offset_samples[pj], 2);
+                    double total = dp[i - 1][pj] + point_cost + collision_weight * seg_cost + smooth_cost;
+                    if (total < dp[i][j])
+                    {
+                        dp[i][j] = total;
+                        parent[i][j] = static_cast<int>(pj);
+                    }
+                }
+            }
+        }
+
+        double best_cost = INF;
+        int best_index = -1;
+        size_t best_stage = N - 1;
+        for (size_t j = 0; j < K; ++j)
+        {
+            if (!valid[N - 1][j])
+            {
+                continue;
+            }
+            if (dp[N - 1][j] < best_cost)
+            {
+                best_cost = dp[N - 1][j];
+                best_index = static_cast<int>(j);
+                best_stage = N - 1;
+            }
+        }
+
+        if (best_index < 0)
+        {
+            for (size_t i = N; i-- > 0;)
+            {
+                for (size_t j = 0; j < K; ++j)
+                {
+                    if (!valid[i][j])
+                    {
+                        continue;
+                    }
+                    if (dp[i][j] < best_cost)
+                    {
+                        best_cost = dp[i][j];
+                        best_index = static_cast<int>(j);
+                        best_stage = i;
+                    }
+                }
+                if (best_index >= 0)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (best_index < 0)
+        {
+            return false;
+        }
+
+        std::vector<Eigen::Vector2d> reversed_path;
+        size_t stage = best_stage;
+        int idx = best_index;
+        while (idx >= 0 && stage < N)
+        {
+            reversed_path.push_back(points[stage][idx]);
+            idx = parent[stage][idx];
+            if (stage == 0)
+            {
+                break;
+            }
+            stage--;
+        }
+
+        if (reversed_path.empty())
+        {
+            return false;
+        }
+
+        best_path.assign(reversed_path.rbegin(), reversed_path.rend());
+        return true;
+    }
+
+    double FTCPlanner::costAt(const Eigen::Vector2d &point, bool &lethal)
+    {
+        lethal = false;
+        unsigned int mx = 0, my = 0;
+        if (!costmap_map_->worldToMap(point.x(), point.y(), mx, my))
+        {
+            lethal = true;
+            return 1.0;
+        }
+
+        unsigned char cost = costmap_map_->getCost(mx, my);
+        if (cost >= config.corridor_lethal_cost)
+        {
+            lethal = true;
+        }
+
+        return static_cast<double>(cost) / 255.0;
+    }
+
+    double FTCPlanner::segmentCollisionCost(const Eigen::Vector2d &from, const Eigen::Vector2d &to, bool &lethal)
+    {
+        lethal = false;
+        Eigen::Vector2d delta = to - from;
+        double length = delta.norm();
+        double step = std::max(0.01, config.corridor_sampling_step);
+        int steps = std::max(1, static_cast<int>(std::ceil(length / step)));
+
+        double total_cost = 0.0;
+        for (int i = 1; i <= steps; ++i)
+        {
+            double ratio = static_cast<double>(i) / static_cast<double>(steps);
+            Eigen::Vector2d sample = from + delta * ratio;
+            bool sample_lethal = false;
+            double c = costAt(sample, sample_lethal);
+            if (sample_lethal)
+            {
+                lethal = true;
+                return std::numeric_limits<double>::infinity();
+            }
+            total_cost += c;
+        }
+
+        return total_cost / static_cast<double>(steps);
+    }
+
+    void FTCPlanner::publishCorridorDebug(const std::string &frame_id, const std::vector<Eigen::Vector2d> &centerline,
+                                          const std::vector<double> &headings,
+                                          const std::vector<std::pair<double, double>> &bounds,
+                                          const std::vector<Eigen::Vector2d> &best_path)
+    {
+        if (!config.corridor_publish_debug)
+        {
+            return;
+        }
+
+        ros::Time stamp = ros::Time::now();
+
+        if (corridor_centerline_pub_.getNumSubscribers() > 0)
+        {
+            nav_msgs::Path centerline_msg;
+            centerline_msg.header.frame_id = frame_id;
+            centerline_msg.header.stamp = stamp;
+            centerline_msg.poses.reserve(centerline.size());
+            for (const auto &pt : centerline)
+            {
+                geometry_msgs::PoseStamped pose;
+                pose.header = centerline_msg.header;
+                pose.pose.position.x = pt.x();
+                pose.pose.position.y = pt.y();
+                pose.pose.orientation.w = 1.0;
+                centerline_msg.poses.push_back(pose);
+            }
+            corridor_centerline_pub_.publish(centerline_msg);
+        }
+
+        if (best_trajectory_pub_.getNumSubscribers() > 0 && !best_path.empty())
+        {
+            nav_msgs::Path best_msg;
+            best_msg.header.frame_id = frame_id;
+            best_msg.header.stamp = stamp;
+            best_msg.poses.reserve(best_path.size());
+            for (size_t i = 0; i < best_path.size(); ++i)
+            {
+                geometry_msgs::PoseStamped pose;
+                pose.header = best_msg.header;
+                pose.pose.position.x = best_path[i].x();
+                pose.pose.position.y = best_path[i].y();
+                double yaw = 0.0;
+                if (i + 1 < best_path.size())
+                {
+                    Eigen::Vector2d dir = best_path[i + 1] - best_path[i];
+                    yaw = std::atan2(dir.y(), dir.x());
+                }
+                else if (!best_path.empty() && i > 0)
+                {
+                    Eigen::Vector2d dir = best_path[i] - best_path[i - 1];
+                    yaw = std::atan2(dir.y(), dir.x());
+                }
+                tf2::Quaternion q;
+                q.setRPY(0.0, 0.0, yaw);
+                pose.pose.orientation = tf2::toMsg(q);
+                best_msg.poses.push_back(pose);
+            }
+            best_trajectory_pub_.publish(best_msg);
+        }
+
+        if (corridor_boundary_pub_.getNumSubscribers() > 0 && !centerline.empty())
+        {
+            visualization_msgs::Marker bounds_marker;
+            bounds_marker.header.frame_id = frame_id;
+            bounds_marker.header.stamp = stamp;
+            bounds_marker.ns = "corridor_bounds";
+            bounds_marker.id = 0;
+            bounds_marker.type = visualization_msgs::Marker::LINE_LIST;
+            bounds_marker.action = visualization_msgs::Marker::ADD;
+            bounds_marker.scale.x = 0.05;
+            bounds_marker.color.r = 0.2f;
+            bounds_marker.color.g = 0.7f;
+            bounds_marker.color.b = 1.0f;
+            bounds_marker.color.a = 0.8f;
+
+            for (size_t i = 0; i < centerline.size(); ++i)
+            {
+                Eigen::Vector2d normal(-std::sin(headings[i]), std::cos(headings[i]));
+                geometry_msgs::Point left, right;
+                Eigen::Vector2d left_vec = centerline[i] + normal * bounds[i].second;
+                Eigen::Vector2d right_vec = centerline[i] + normal * bounds[i].first;
+                left.x = left_vec.x();
+                left.y = left_vec.y();
+                left.z = 0.0;
+                right.x = right_vec.x();
+                right.y = right_vec.y();
+                right.z = 0.0;
+                bounds_marker.points.push_back(left);
+                bounds_marker.points.push_back(right);
+            }
+
+            corridor_boundary_pub_.publish(bounds_marker);
+        }
     }
 
     void FTCPlanner::calculate_velocity_commands(double dt, geometry_msgs::TwistStamped &cmd_vel)


### PR DESCRIPTION
## Summary
- add dynamic reconfigure parameters to control corridor construction, scoring weights, and debug publishing
- extend the planner with corridor-aware target selection, DP-based candidate evaluation, and debug visualization topics
- expose helper utilities for sampling corridor bounds, computing collision costs, and publishing diagnostic paths

## Testing
- not run (package is not inside a catkin workspace in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbe8c6f788832585276d1a35440e8c